### PR TITLE
[HS-968] Agent Options: Limit Agent Options According to their Status

### DIFF
--- a/src/api/channels/adapters.ts
+++ b/src/api/channels/adapters.ts
@@ -3,6 +3,11 @@ import { checkWhatsAppIntegration } from "./requests";
 export interface WhatsAppIntegrationResponse {
     success: boolean;
     error?: string;
+    data?: {
+        has_whatsapp: boolean;
+        wpp_cloud_app_uuid: string;
+        flows_channel_uuid: string;
+    };
 }
 
 export interface WhatsAppAdapter {
@@ -18,7 +23,7 @@ export class VTEXWhatsAppAdapter implements WhatsAppAdapter {
                 throw new Error(response?.error || '');
             }
 
-            return { success: true };
+            return { success: true, data: response.data };
         } catch (error: unknown) {
             console.error('error verifying WhatsApp integration:', error);
             return { success: false, error: error instanceof Error ? error.message : 'unknown error' };

--- a/src/components/FeatureBox.tsx
+++ b/src/components/FeatureBox.tsx
@@ -1,6 +1,6 @@
 import { Button, Flex, IconButton, IconCheck, IconDotsThreeVertical, IconGearSix, IconInfo, IconPauseCircle, IconPlus, MenuItem, MenuPopover, MenuProvider, MenuSeparator, MenuTrigger, Spinner, Text, toast } from "@vtex/shoreline";
 import { AboutAgent } from "./AboutAgent";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { integrateAgent } from "../services/agent.service";
 import { useSelector } from "react-redux";
 import { agents, agentsLoading, getAgentChannel, selectProject} from "../store/projectSlice";
@@ -45,6 +45,19 @@ export function FeatureBox({ uuid, code, type, isIntegrated, isInTest, isConfigu
       toast.success(t('integration.success'));
     }
   }
+
+  const status = useMemo(() => {
+    if (isInTest) {
+      return 'test';
+    } else if (isConfiguring) {
+      return 'configuring';
+    } else if (isIntegrated) {
+      return 'integrated';
+    } else {
+      return 'availableToIntegrate';
+    }
+  }, [isInTest, isConfiguring, isIntegrated]);
+  
   return (
     <>
       <Flex
@@ -79,17 +92,24 @@ export function FeatureBox({ uuid, code, type, isIntegrated, isInTest, isConfigu
                 {t('common.details')}
               </MenuItem>
 
-              <MenuItem onClick={toggleIsPreferencesOpen}>
-                <IconGearSix />
-                {t('common.manage_settings')}
-              </MenuItem>
+              {
+                ['test', 'configuring', 'integrated'].includes(status)
+                && (
+                  <>
+                    <MenuItem onClick={toggleIsPreferencesOpen}>
+                      <IconGearSix />
+                      {t('common.manage_settings')}
+                    </MenuItem>
 
-              <MenuSeparator />
+                    <MenuSeparator />
 
-              <MenuItem onClick={openDisableModal}>
-                <IconPauseCircle />
-                {t('common.disable')}
-              </MenuItem>
+                    <MenuItem onClick={openDisableModal}>
+                      <IconPauseCircle />
+                      {t('common.disable')}
+                    </MenuItem>
+                  </>
+                )
+              }
             </MenuPopover>
           </MenuProvider>
         </Flex>
@@ -103,67 +123,64 @@ export function FeatureBox({ uuid, code, type, isIntegrated, isInTest, isConfigu
           </Text>
         </Flex>
 
-
         {(() => {
-          if (isInTest) {
-            return (
-              <Flex
-                style={{
-                  padding: 'var(--sl-space-2)',
-                  alignItems: 'center',
-                  gap: '8px'
-                }}
-              >
-                <img src={wrench} alt="" />
-                <Text variant="action" color="$fg-warning"> {t('agents.common.test')}</Text>
-              </Flex>
-            );
+          switch (status) {
+            case 'test':
+              return (
+                <Flex
+                  style={{
+                    padding: 'var(--sl-space-2)',
+                    alignItems: 'center',
+                    gap: '8px'
+                  }}
+                >
+                  <img src={wrench} alt="" />
+                  <Text variant="action" color="$fg-warning"> {t('agents.common.test')}</Text>
+                </Flex>
+              );
+            case 'configuring':
+              return (
+                <Flex
+                  style={{
+                    padding: 'var(--sl-space-2)',
+                    alignItems: 'center',
+                    gap: '8px'
+                  }}
+                >
+                  <Text variant="action" color="$fg-informational"> {t('agents.common.configuring')}</Text>
+                </Flex>
+              );
+            case 'integrated':
+              return (
+                <Flex
+                  style={{
+                    padding: 'var(--sl-space-2)',
+                    alignItems: 'center',
+                    gap: '8px'
+                  }}
+                >
+                  <IconCheck color="green" />
+                  <Text variant="action" color="$fg-success">
+                    {t('agents.common.added')}
+                  </Text>
+                </Flex>
+              );
+            case 'availableToIntegrate':
+              return (
+                <Button variant="secondary" onClick={integrateCurrentFeature} size="large">
+                  {
+                    isUpdateAgentLoading ?
+                      <Spinner description="loading" />
+                      :
+                      <>
+                        <IconPlus />
+                        <Text> {t('agents.common.add')}</Text>
+                      </>
+                  }
+                </Button>
+              );
           }
-          else if (isConfiguring) {
-            return (
-              <Flex
-                style={{
-                  padding: 'var(--sl-space-2)',
-                  alignItems: 'center',
-                  gap: '8px'
-                }}
-              >
-                <Text variant="action" color="$fg-informational"> {t('agents.common.configuring')}</Text>
-              </Flex>
-            );
-          }
-          else if (isIntegrated) {
-            return (
-              <Flex
-                style={{
-                  padding: 'var(--sl-space-2)',
-                  alignItems: 'center',
-                  gap: '8px'
-                }}
-              >
-                <IconCheck color="green" />
-                <Text variant="action" color="$fg-success">
-                  {t('agents.common.added')}
-                </Text>
-              </Flex>
-            );
-          }
-          return (
-            <Button variant="secondary" onClick={integrateCurrentFeature} size="large">
-              {
-                isUpdateAgentLoading ?
-                  <Spinner description="loading" />
-                  :
-                  <>
-                    <IconPlus />
-                    <Text> {t('agents.common.add')}</Text>
-                  </>
-              }
-            </Button>
-          );
         })()}
-
-
       </Flex>
 
       <AboutAgent

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -113,7 +113,8 @@
             },
             "add": "Add agent",
             "added": "Agent active",
-            "test": "Agent in test"
+            "test": "Agent in test",
+            "configuring": "Configuring agent"
         }
     },
     "setup": {

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -113,7 +113,8 @@
             },
             "add": "Agregar agente",
             "added": "Agente activo",
-            "test": "Agente en prueba"
+            "test": "Agente en prueba",
+            "configuring": "Configurando agente"
         }
     },
     "setup": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -113,7 +113,8 @@
             },
             "add": "Adicionar agente",
             "added": "Agente ativo",
-            "test": "Agente em teste"
+            "test": "Agente em teste",
+            "configuring": "Configurando agente"
         }
     },
     "setup": {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,28 +1,16 @@
 import { Alert, Button, Flex, Grid, Heading, IconArrowUpRight, Page, PageContent, PageHeader, PageHeaderRow, PageHeading, Text } from '@vtex/shoreline';
-import { DashboardItem } from '../components/DashboardItem';
 import { FeatureBox } from '../components/FeatureBox';
 import { useSelector } from 'react-redux';
 import { agents, integratedAgents, selectProject } from '../store/projectSlice';
 import { selectUser } from "../store/userSlice";
-import { useEffect, useState } from 'react';
-import { getSkillMetrics, updateAgentsList } from '../services/agent.service';
+import { useEffect } from 'react';
+import { updateAgentsList } from '../services/agent.service';
 
 export function Dashboard() {
-  const [data, setData] = useState<{ title: string; value: string; variation: number }[][]>([]);
   const agentsList = useSelector(agents)
   const integrated = useSelector(integratedAgents)
   const project_uuid = useSelector(selectProject)
   const userData = useSelector(selectUser);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const response = await getSkillMetrics();
-      if ('data' in response) {
-        setData(response.data);
-      }
-    };
-    fetchData();
-  }, []);
 
   function navigateToAgent() {
     const dash = new URL(`https://dash.stg.cloud.weni.ai/projects/${project_uuid}`);
@@ -86,63 +74,6 @@ export function Dashboard() {
               </Button>
             </Flex>
           </Alert>
-
-          <Flex
-            direction="column"
-            gap="$space-0"
-          >
-            {data.map((line, indexOfLine) => (
-              <Grid
-                key={`line-${indexOfLine}`}
-                columns="1fr 1fr 1fr"
-                gap="$space-0"
-                style={{
-                  borderBottom: indexOfLine !== data.length - 1 ? 'var(--sl-border-base)' : undefined,
-                }}
-              >
-                {line.map((detail, indexOfDetail) => (
-                  <DashboardItem
-                    key={`detail-${detail.value}`}
-                    title={detail.title}
-                    value={detail.value}
-                    percentageDifference={detail.variation}
-                    style={{
-                      borderRight: indexOfDetail !== line.length - 1 ? 'var(--sl-border-base)' : undefined,
-                    }}
-                  />
-                ))}
-              </Grid>
-            ))}
-          </Flex>
-
-          <Flex
-            direction="column"
-            gap="$space-0"
-          >
-            {data.map((line, indexOfLine) => (
-              <Grid
-                key={`line-${indexOfLine}`}
-                columns="1fr 1fr 1fr"
-                gap="$space-0"
-                style={{
-                  borderBottom: indexOfLine !== data.length - 1 ? 'var(--sl-border-base)' : undefined,
-                }}
-              >
-                {line.map((detail, indexOfDetail) => (
-                  <DashboardItem
-                    key={`detail-${detail.value}`}
-                    title={detail.title}
-                    value={detail.value}
-                    percentageDifference={detail.variation}
-                    style={{
-                      borderRight: indexOfDetail !== line.length - 1 ? 'var(--sl-border-base)' : undefined,
-                    }}
-                  />
-                ))}
-              </Grid>
-            ))}
-          </Flex>
-
 
           <Heading
             variant="display2"

--- a/src/pages/setup/useUserSetup.ts
+++ b/src/pages/setup/useUserSetup.ts
@@ -50,7 +50,7 @@ export function useUserSetup() {
         await updateAgentsList();
 
         const response = await checkWppIntegration(project_uuid);
-        const { has_whatsapp = false, flows_channel_uuid = null, wpp_cloud_app_uuid = null } = response.data.data || {};
+        const { has_whatsapp = false, flows_channel_uuid = null, wpp_cloud_app_uuid = null } = response.data || {};
 
         if (response?.error) {
           throw new Error(JSON.stringify(response.error))


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In order to correct agent options, where previously all options were shown regardless of agent status, this PR aims to limit options by agent status. It was also used to correct an error in the response in the channels adapter and remove non-functioning code.

### Summary of Changes
<!--- Describe your changes in detail -->
* Limits Agent options according to Agent status;
* Removes skill metrics non-functioning code;
* Adjusts channels adapter to receive response data properly;
* Adds missing translations.