### PR TITLE
[HS-969] Agent Builder: Discart URL Prefix when Provided

### DIFF
--- a/src/pages/agent/AgentBuilder.tsx
+++ b/src/pages/agent/AgentBuilder.tsx
@@ -46,7 +46,7 @@ export function AgentBuilder() {
     knowledge: useSelector(getAgentBuilder).links[0] || '',
     occupation: useSelector(getAgentBuilder).occupation || t('agent.setup.forms.occupation.default'),
     objective: useSelector(getAgentBuilder).objective || t('agent.setup.forms.objective.default'),
-    channel: useSelector(getAgentBuilder).channel|| t('agent.setup.forms.channel.default'),
+    channel: useSelector(getAgentBuilder).channel || t('agent.setup.forms.channel.default'),
   });
   const [errors, setErrors] = useState<{ [key in keyof FormState]?: string }>({});
   const [openTerms, setOpenTerms] = useState(false)
@@ -113,7 +113,7 @@ export function AgentBuilder() {
               </IconButton>
               <Text>{t('common.new_agent')}</Text>
             </PageHeading>
-            <Button variant="primary" size="large" onClick={handleOpenTerms} disabled={!isWppIntegrated || isAgentBuilderLoading}>
+            <Button variant="primary" size="large" onClick={handleOpenTerms} disabled={!isWppIntegrated || isAgentBuilderLoading || !form.channel}>
               {isAgentBuilderLoading ? <Spinner description="loading" /> : <span>{t('common.create')}</span>}
             </Button>
           </PageHeaderRow>
@@ -126,9 +126,9 @@ export function AgentBuilder() {
               onChange={(e: ChangeEvent<HTMLInputElement>) => setForm({ ...form, channel: e.target.value })}
             >
               <Flex direction="row" gap="var(--space-5, 20px)">
-                <Radio value={'faststore'}>{t('agent.setup.forms.channel.faststore')}</Radio>
-                <Radio value={'portal'}>{t('agent.setup.forms.channel.portal')}</Radio>
-                <Radio value={'site_editor'}>{t('agent.setup.forms.channel.site_editor')}</Radio>
+                <Radio value={'faststore'} checked={form.channel === 'faststore'}>{t('agent.setup.forms.channel.faststore')}</Radio>
+                <Radio value={'portal'} checked={form.channel === 'portal'}>{t('agent.setup.forms.channel.portal')}</Radio>
+                <Radio value={'site_editor'} checked={form.channel === 'site_editor'}>{t('agent.setup.forms.channel.site_editor')}</Radio>
               </Flex>
             </RadioGroup>
           </Flex>

--- a/src/pages/agent/AgentBuilder.tsx
+++ b/src/pages/agent/AgentBuilder.tsx
@@ -79,8 +79,13 @@ export function AgentBuilder() {
     return !Object.values(newErrors).some((error) => error);
   };
 
-  const handleInputChange = (field: keyof FormState, value: string) =>
+  const handleInputChange = (field: keyof FormState, value: string) => {
+    if (field === 'knowledge') {
+      value = value.trim().replace(/^https?:\/\//, '');
+    }
+
     setForm((prev) => ({ ...prev, [field]: value }));
+  }
 
   const handleOpenTerms = () => {
     if (validateForm() && isWppIntegrated) {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When the user entered a url with the prefix `http://` or `https://`, it generated an error when saving.

### Summary of Changes
<!--- Describe your changes in detail -->
* Removes `http://` or `https://` prefix when the user enters it;
* Fixes the Store type radio checked.