### PR TITLE
[HS-1269] Agent: Publish and Switch to Test Mode Modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
     <script>
       //CONFIGURATIONS_PLACEHOLDER
     </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/agent/modals/Publish.tsx
+++ b/src/components/agent/modals/Publish.tsx
@@ -1,0 +1,44 @@
+import { Button, Field, FieldDescription, Flex, Input, Label, Modal, ModalContent, ModalDismiss, ModalFooter, ModalHeader, ModalHeading, Text } from "@vtex/shoreline";
+
+export function PublishModal({ open, onClose, onPublish }: { open: boolean, onClose: () => void, onPublish: () => void }) {
+  return (
+    <Modal open={open} onClose={onClose}>
+      <ModalHeader>
+        <ModalHeading>{t('agent.modals.publish.title')}</ModalHeading>
+        <ModalDismiss />
+      </ModalHeader>
+
+      <ModalContent>
+        <Flex direction="column" gap="$space-4">
+          <Text variant="body" color="$fg-base">
+            {t('agent.modals.publish.description')}
+          </Text>
+
+          <Flex direction="column">
+            <Field>
+              <Label>{t('agent.modals.publish.fields.percentage.title')}</Label>
+
+              <Input suffix="%" />
+
+              <FieldDescription>
+                {t('agent.modals.publish.fields.percentage.description')}
+              </FieldDescription>
+            </Field>
+          </Flex>
+        </Flex>
+      </ModalContent>
+
+      <ModalFooter>
+        <Button size="large" onClick={onClose}>{t('agent.modals.publish.buttons.cancel')}</Button>
+
+        <Button
+          size="large"
+          variant="primary"
+          onClick={() => { onPublish(); onClose(); }}
+        >
+          {t('agent.modals.publish.buttons.publish')}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  )
+}

--- a/src/components/agent/modals/SwitchToTestMode.tsx
+++ b/src/components/agent/modals/SwitchToTestMode.tsx
@@ -1,0 +1,30 @@
+import { Button, Modal, ModalContent, ModalDismiss, ModalFooter, ModalHeader, ModalHeading, Text } from "@vtex/shoreline";
+
+export function SwitchToTestModeModal({ open, onClose, onTest }: { open: boolean, onClose: () => void, onTest: () => void }) {
+  return (
+    <Modal open={open} onClose={onClose} size="small">
+      <ModalHeader>
+        <ModalHeading>{t('agent.modals.switch_to_test.title')}</ModalHeading>
+        <ModalDismiss />
+      </ModalHeader>
+
+      <ModalContent>
+        <Text variant="body" color="$fg-base">
+          {t('agent.modals.switch_to_test.description')}
+        </Text>
+      </ModalContent>
+
+      <ModalFooter>
+        <Button size="large" onClick={onClose}>{t('agent.modals.switch_to_test.buttons.cancel')}</Button>
+
+        <Button
+          size="large"
+          variant="critical"
+          onClick={() => { onTest(); onClose(); }}
+        >
+          {t('agent.modals.switch_to_test.buttons.confirm')}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  )
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -18,6 +18,14 @@ i18n.use(initReactI18next).init({
   },
 });
 
+i18n.services.formatter?.add('lowerCase', (value: string) => {
+  return value.toLowerCase();
+});
+
+i18n.services.formatter?.add('firstLetterUpperCase', (value: string) => {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+});
+
 export const t = i18n.t.bind(i18n);
 
 export default i18n;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -131,6 +131,38 @@
         "description": "We're getting everything ready for you! The initial setup will be completed soon to ensure a great experience."
     },
     "agent": {
+        "actions": {
+            "publish": {
+                "success": "{{agentName, lowerCase, firstLetterUpperCase}} published"
+            },
+            "switch_to_test": {
+                "success": "{{agentName, lowerCase, firstLetterUpperCase}} switched to test mode"
+            }
+        },
+        "modals": {
+            "publish": {
+                "title": "Publish and go live",
+                "description": "Confirming this action will publish the agent to production, where it will begin handling live interactions.",
+                "fields": {
+                    "percentage": {
+                        "title": "Percentage of the contact base that will be triggered",
+                        "description": "Try a smaller percentage if you just want to test with part of your base"
+                    }
+                },
+                "buttons": {
+                    "publish": "Publish",
+                    "cancel": "Cancel"
+                }
+            },
+            "switch_to_test": {
+                "title": "Switch to test mode",
+                "description": "Confirming this action will move the agent to test mode, disabling it from handling live interactions.",
+                "buttons": {
+                    "confirm": "Confirm",
+                    "cancel": "Cancel"
+                }
+            }
+        },
         "details": {
             "title": "Smart agents",
             "description": "Enhance your smart agents by enabling control over conversation flows based on user intent. With the Starter Plan, you can customize language, tone, and behavior to give your agent a unique identity and improve communication quality. See the exchanges and returns agent demo on the side.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -131,6 +131,11 @@
         "description": "We're getting everything ready for you! The initial setup will be completed soon to ensure a great experience."
     },
     "agent": {
+        "buttons": {
+            "preview": "Preview",
+            "publish": "Publish and go live",
+            "switch_to_test": "Switch to test mode"
+        },
         "actions": {
             "publish": {
                 "success": "{{agentName, lowerCase, firstLetterUpperCase}} published"

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -131,6 +131,11 @@
         "description": "La configuración inicial está en proceso. En breve estará todo listo para que tengas una excelente experiencia."
     },
     "agent": {
+        "buttons": {
+            "preview": "Vista previa",
+            "publish": "Publicar y poner en vivo",
+            "switch_to_test": "Pasar a modo de prueba"
+        },
         "actions": {
             "publish": {
                 "success": "{{agentName, lowerCase, firstLetterUpperCase}} publicado"

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -131,6 +131,38 @@
         "description": "La configuración inicial está en proceso. En breve estará todo listo para que tengas una excelente experiencia."
     },
     "agent": {
+        "actions": {
+            "publish": {
+                "success": "{{agentName, lowerCase, firstLetterUpperCase}} publicado"
+            },
+            "switch_to_test": {
+                "success": "{{agentName, lowerCase, firstLetterUpperCase}} pasado a modo de prueba"
+            }
+        },
+        "modals": {
+            "publish": {
+                "title": "Publicar y poner en vivo",
+                "description": "Confirmar esta acción publicará el agente en producción, donde comenzará a manejar interacciones en vivo.",
+                "fields": {
+                    "percentage": {
+                        "title": "Porcentaje de la base de contactos que será activado",
+                        "description": "Intenta con un porcentaje menor si solo quieres probar con parte de tu base"
+                    }
+                },
+                "buttons": {
+                    "publish": "Publicar",
+                    "cancel": "Cancelar"
+                }
+            },
+            "switch_to_test": {
+                "title": "Pasar a modo de prueba",
+                "description": "Confirmar esta acción moverá el agente a modo de prueba, desactivando su manejo de interacciones en vivo.",
+                "buttons": {
+                    "confirm": "Confirmar",
+                    "cancel": "Cancelar"
+                }
+            }
+        },
         "details": {
             "title": "Agentes inteligentes",
             "description": "Optimiza tus agentes inteligentes activando el control sobre los flujos de conversación adaptados a las intenciones del usuario. Con el plan Starter, personaliza el lenguaje, el tono y el comportamiento para darles una identidad única y mejorar la calidad de la comunicación. A la derecha puedes consultar una demostración del agente de cambios y devoluciones.",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -131,6 +131,38 @@
         "description": "Estamos preparando tudo para você! Em breve, a configuração inicial será concluída para que você tenha uma excelente experiência."
     },
     "agent": {
+        "actions": {
+            "publish": {
+                "success": "{{agentName, lowerCase, firstLetterUpperCase}} publicado"
+            },
+            "switch_to_test": {
+                "success": "{{agentName, lowerCase, firstLetterUpperCase}} passado para o modo de teste"
+            }
+        },
+        "modals": {
+            "publish": {
+                "title": "Publicar e ir para o vivo",
+                "description": "Confirmar esta ação publicará o agente para produção, onde ele começará a lidar com interações em tempo real.",
+                "fields": {
+                    "percentage": {
+                        "title": "Porcentagem da base de contatos que será acionada",
+                        "description": "Tente um percentual menor se você quiser testar com parte da sua base"
+                    }
+                },
+                "buttons": {
+                    "publish": "Publicar",
+                    "cancel": "Cancelar"
+                }
+            },
+            "switch_to_test": {
+                "title": "Passar para o modo de teste",
+                "description": "Confirmar esta ação moverá o agente para o modo de teste, desativando-o de lidar com interações em tempo real.",
+                "buttons": {
+                    "confirm": "Confirmar",
+                    "cancel": "Cancelar"
+                }
+            }
+        },
         "details": {
             "title": "Agentes inteligentes",
             "description": "Aprimore os agentes inteligentes habilitando o controle sobre fluxos de conversação baseados nas intenções do usuário. Com o Plano Starter, personalize a linguagem, o tom e o comportamento para dar ao agente uma identidade única e melhorar a qualidade da comunicação. Veja ao lado a demonstração da interação com o agente de trocas e devoluções.",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -131,6 +131,11 @@
         "description": "Estamos preparando tudo para você! Em breve, a configuração inicial será concluída para que você tenha uma excelente experiência."
     },
     "agent": {
+        "buttons": {
+            "preview": "Prévia",
+            "publish": "Publicar e entrar no ar",
+            "switch_to_test": "Mudar para o modo de teste"
+        },
         "actions": {
             "publish": {
                 "success": "{{agentName, lowerCase, firstLetterUpperCase}} publicado"

--- a/src/pages/agent/Index.tsx
+++ b/src/pages/agent/Index.tsx
@@ -1,6 +1,9 @@
-import { Button, Flex, IconPlus, Page, PageContent, Text } from '@vtex/shoreline';
+import { Bleed, Button, Flex, IconArrowLeft, IconButton, IconPlus, Page, PageContent, PageHeader, PageHeaderRow, PageHeading, Stack, Text, toast } from '@vtex/shoreline';
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { TemplateCard, TemplateCardContainer } from '../../components/TemplateCard';
+import { PublishModal } from '../../components/agent/modals/Publish';
+import { SwitchToTestModeModal } from '../../components/agent/modals/SwitchToTestMode';
 
 export interface Template {
   name: string;
@@ -36,6 +39,12 @@ export function AgentIndex() {
   const navigate = useNavigate();
   const { agentUuid } = useParams();
 
+  const agentName = 'Order Status';
+  const [agentStatus, setAgentStatus] = useState<'test' | 'production'>('test');
+
+  const [isSwitchToTestModeModalOpen, setIsSwitchToTestModeModalOpen] = useState(false);
+  const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
+
   const templates: Template[] = [
     {
       name: 'Payment Approved',
@@ -63,10 +72,76 @@ export function AgentIndex() {
     navigate(`/agents/${agentUuid}/templates/create`);
   }
 
+  function handlePublish() {
+    setAgentStatus('production');
+    toast.success(t('agent.actions.publish.success', { agentName }));
+  }
+
+  function handleTest() {
+    setAgentStatus('test');
+    toast.success(t('agent.actions.switch_to_test.success', { agentName }));
+  }
+
   return (
     <Page>
+      <PageHeader>
+        <PageHeaderRow>
+          <Flex align="center">
+            <Bleed top="$space-2" bottom="$space-2">
+              <IconButton
+                label={t('common.return')}
+                asChild
+                variant="tertiary"
+                size="large"
+                onClick={() => navigate(-1)}
+              >
+                <IconArrowLeft />
+              </IconButton>
+            </Bleed>
+
+            <PageHeading>{agentName}</PageHeading>
+          </Flex>
+
+          <Stack space="$space-3" horizontal>
+            <Bleed top="$space-2" bottom="$space-2">
+              <Button variant="secondary" size="large">
+                {t('agent.buttons.preview')}
+              </Button>
+            </Bleed>
+
+            {agentStatus === 'test' && (
+              <Bleed top="$space-2" bottom="$space-2">
+                <Button variant="primary" size="large" onClick={() => setIsPublishModalOpen(true)}>
+                  {t('agent.buttons.publish')}
+                </Button>
+              </Bleed>
+            )}
+
+            {agentStatus === 'production' && (
+              <Bleed top="$space-2" bottom="$space-2">
+                <Button variant="critical" size="large" onClick={() => setIsSwitchToTestModeModalOpen(true)}>
+                  {t('agent.buttons.switch_to_test')}
+                </Button>
+              </Bleed>
+            )}
+          </Stack>
+        </PageHeaderRow>
+      </PageHeader>
+
       <PageContent>
         <TemplateList navigateToCreateTemplate={navigateToCreateTemplate} templates={templates} />
+
+        <SwitchToTestModeModal
+          open={isSwitchToTestModeModalOpen}
+          onClose={() => setIsSwitchToTestModeModalOpen(false)}
+          onTest={handleTest}
+        />
+
+        <PublishModal
+          open={isPublishModalOpen}
+          onClose={() => setIsPublishModalOpen(false)}
+          onPublish={handlePublish}
+        />
       </PageContent>
     </Page>
   )


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR adds the modes of publishing and switching the agent to test mode. It also adds the Inter font that is used within Shoreline's Design System.

### Summary of Changes
<!--- Describe your changes in detail -->
* Adds Publish and Switch to Test Mode modals;
* Adds the Inter font used in the Shoreline Design System.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [App - Agents Gallery - Publish/test agent](https://www.figma.com/design/USjZMKo3y9WaQcHzxkvZUd/App---Agents-Gallery?node-id=116-11246&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
![image](https://github.com/user-attachments/assets/44682dcf-dff2-47de-9fde-d114d3c2ecbc)
![image](https://github.com/user-attachments/assets/f8223c92-f13f-4417-a05a-45f4a9d07cf9)
