### PR TITLE
[HS-1525] Template: Select or Create Variable from Typing {{ on the Content Text Textarea

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -641,7 +641,7 @@
                 "start_condition": {
                     "label": "Start condition",
                     "description": "Defines the condition that starts the agent.",
-                    "help": "Visits to the store which can include a series of user interactions and end after 30 minutes of inactivity."
+                    "help": "Start condicition example: “When a webhook is received with status = approved”"
                 },
                 "content": {
                     "label": "Text content",

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -641,7 +641,7 @@
                 "start_condition": {
                     "label": "Condición de inicio",
                     "description": "Define la condición que inicia el agente.",
-                    "help": "Visitas al almacén que pueden incluir una serie de interacciones del usuario y finalizan después de 30 minutos de inactividad."
+                    "help": "Ejemplo de condición de inicio: “Cuando se recibe un webhook con status = aprobado”"
                 },
                 "content": {
                     "label": "Contenido de texto",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -641,7 +641,7 @@
                 "start_condition": {
                     "label": "Condição de início",
                     "description": "Define a condição que inicia o agente.",
-                    "help": "Visitas ao loja que podem incluir uma série de interações do usuário e terminam após 30 minutos de inatividade."
+                    "help": "Exemplo de condição de início: “Quando um webhook é recebido com status = aprovado”"
                 },
                 "content": {
                     "label": "Conteúdo de texto",

--- a/src/pages/template/Template.tsx
+++ b/src/pages/template/Template.tsx
@@ -50,6 +50,8 @@ export function Template() {
   const [templateStatus, setTemplateStatus] = useState<"active" | "pending" | "rejected" | "needs-editing">('active');
   const [startCondition, setStartCondition] = useState('');
 
+  const [temporaryContentText, setTemporaryContentText] = useState('');
+
   const [content, setContent] = useState<Content>({
     header: undefined,
     content: '',
@@ -375,6 +377,11 @@ export function Template() {
 
                 setVariables([...variables, ...newVariables]);
               }}
+              openNewVariableModal={(text: string) => {
+                setIsAddingVariableModalOpen(true);
+                setTemporaryContentText(text);
+              }}
+              variables={variables.map((variable) => variable.definition)}
             />
 
             <MessagePreview
@@ -396,8 +403,18 @@ export function Template() {
 
             <AddingVariableModal
               open={isAddingVariableModalOpen}
-              onClose={() => setIsAddingVariableModalOpen(false)}
+              onClose={() => {
+                setIsAddingVariableModalOpen(false);
+                setTemporaryContentText('');
+              }}
               addVariable={(variable: Variable) => {
+                if (temporaryContentText) {
+                  setPrefilledContent({
+                    ...prefilledContent,
+                    content: temporaryContentText.replace(/{{toBeReplaced(}})?/, `{{${variables.length + 1}}}`),
+                  });
+                }
+
                 setVariables([...variables, variable]);
               }}
             />

--- a/src/pages/template/TextareaClone.tsx
+++ b/src/pages/template/TextareaClone.tsx
@@ -1,0 +1,38 @@
+import { forwardRef } from "react";
+
+export function calculateCursorPosition(originalElement: HTMLTextAreaElement, cloneElement: HTMLTextAreaElement, contentText: string) {
+  const style = originalElement.computedStyleMap();
+
+  ['padding', 'border', 'font', 'white-space-collapse'].forEach((attribute) => {
+    cloneElement.style[attribute as 'padding' | 'border' | 'font' | 'whiteSpaceCollapse'] = style.get(attribute)?.toString() ?? ''
+  })
+
+  cloneElement.style['width'] = originalElement.offsetWidth + 'px';
+
+  cloneElement.innerHTML = '';
+  cloneElement.innerText = contentText.slice(0, originalElement.selectionStart);
+
+  const end = document.createElement('span');
+  end.appendChild(document.createTextNode(''));
+  cloneElement.appendChild(end);
+  cloneElement.appendChild(document.createTextNode(contentText.slice(originalElement.selectionStart)));
+
+  return {
+    x: end.offsetLeft,
+    y: end.offsetTop,
+  }
+}
+
+export const TextareaClone = forwardRef<HTMLDivElement>((props, ref) => {
+  return <div ref={ref} {...props} style={{
+    height: 0,
+    position: 'absolute',
+    userSelect: 'none',
+    pointerEvents: 'none',
+    opacity: 0,
+  }}>
+    <textarea />
+  </div>;
+});
+
+TextareaClone.displayName = 'TextareaClone';

--- a/src/pages/template/TextareaClone.tsx
+++ b/src/pages/template/TextareaClone.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from "react";
 
-export function calculateCursorPosition(originalElement: HTMLTextAreaElement, cloneElement: HTMLTextAreaElement, contentText: string) {
+export function calculateCursorPosition(originalElement: HTMLTextAreaElement, cloneElement: HTMLElement, contentText: string) {
   const style = originalElement.computedStyleMap();
 
   ['padding', 'border', 'font', 'white-space-collapse'].forEach((attribute) => {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Summary of Changes
<!--- Describe your changes in detail -->
* Adds content textarea clone to calculate cursor real x and y positions;
* Adds modal to select between already created variables or create a new one.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [App - Agents Gallery - Template](https://www.figma.com/design/USjZMKo3y9WaQcHzxkvZUd/App---Agents-Gallery?node-id=216-10061&t=UQBioTdScl5NGzLg-4)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
![image](https://github.com/user-attachments/assets/00d9af61-bdcc-4e70-902b-badb1ec09d2a)
