### PR TITLE
feat(onboarding): whatsapp activation modal

### DIFF
--- a/src/api/onboarding/adapters.ts
+++ b/src/api/onboarding/adapters.ts
@@ -2,14 +2,14 @@ import { OnboardStatus } from "../../interfaces/Store";
 import { 
   ensureProjectAndUser, 
   fetchOnboardingStatus, 
-  startCrawling, 
+  startOnboardingSetup,
   updateOnboarding, 
   updateWebchatDisplayRatio, 
   activatePixelApp,
   getWebchatConfig,
 } from "./requests";
-import type { WebchatConfigResponse } from "./requests";
-import type { CrawlingChannel } from "../../constants/onboarding";
+import type { WebchatConfigResponse, WhatsAppChannelData } from "./requests";
+import type { SetupChannel } from "../../constants/onboarding";
 
 export interface OnboardStatusResponse {
   success: boolean;
@@ -23,7 +23,7 @@ export interface EnsureProjectAndUserResponse {
   data?: { project_uuid: string; user_uuid: string };
 }
 
-export interface StartCrawlingResponse {
+export interface StartOnboardingSetupResponse {
   success: boolean;
   error?: string;
   data?: { status: string };
@@ -58,10 +58,10 @@ export interface GetWebchatConfigResponse {
 export interface OnboardAdapter {
   getOnboardingStatus(vtex_account: string): Promise<OnboardStatusResponse>;
   ensureProjectAndUser(vtex_account: string, user_email: string): Promise<EnsureProjectAndUserResponse>;
-  startCrawling(vtex_account: string, url: string, channel: CrawlingChannel): Promise<StartCrawlingResponse>;
+  startOnboardingSetup(vtex_account: string, url: string, channel: SetupChannel, channelData?: WhatsAppChannelData): Promise<StartOnboardingSetupResponse>;
   updateOnboarding(vtex_account: string, data: { current_page?: string; completed?: boolean; skipped?: boolean }): Promise<UpdateOnboardingResponse>;
   updateDisplayRatio(webchatAppUuid: string, newConfig: object): Promise<UpdateDisplayRatioResponse>;
-  activateInStore(channel: CrawlingChannel, appUuid: string, accountId: string): Promise<ActivateInStoreResponse>;
+  activateInStore(channel: SetupChannel, appUuid: string, accountId: string): Promise<ActivateInStoreResponse>;
   getWebchatConfig(webchatAppUuid: string): Promise<GetWebchatConfigResponse>;
 }
 
@@ -92,15 +92,15 @@ export class VTEXOnboardAdapter implements OnboardAdapter {
     }
   }
 
-  async startCrawling(vtex_account: string, url: string, channel: CrawlingChannel): Promise<StartCrawlingResponse> {
+  async startOnboardingSetup(vtex_account: string, url: string, channel: SetupChannel, channelData?: WhatsAppChannelData): Promise<StartOnboardingSetupResponse> {
     try {
-      const response = await startCrawling(vtex_account, url, channel);
+      const response = await startOnboardingSetup(vtex_account, url, channel, channelData);
       if (!response) {
-        throw new Error('error starting crawling.');
+        throw new Error('error starting onboarding setup.');
       }
       return { success: true, data: { status: response.status } };
     } catch (error) {
-      console.error('error starting crawling:', error);
+      console.error('error starting onboarding setup:', error);
       return { success: false, error: error instanceof Error ? error.message : 'unknown error' };
     }
   }
@@ -137,7 +137,7 @@ export class VTEXOnboardAdapter implements OnboardAdapter {
     }
   }
 
-  async activateInStore(channel: CrawlingChannel, appUuid: string, accountId: string): Promise<ActivateInStoreResponse> {
+  async activateInStore(channel: SetupChannel, appUuid: string, accountId: string): Promise<ActivateInStoreResponse> {
     try {
       await activatePixelApp(channel, appUuid, accountId);
       return { success: true };

--- a/src/api/onboarding/requests.ts
+++ b/src/api/onboarding/requests.ts
@@ -1,7 +1,7 @@
 import getEnv from "../../utils/env";
 import { proxy } from "../proxy";
 import { OnboardStatus } from "../../interfaces/Store";
-import type { CrawlingChannel } from "../../constants/onboarding";
+import type { SetupChannel } from "../../constants/onboarding";
 
 export interface WebchatConfigResponse {
   displayRatio: number;
@@ -34,14 +34,26 @@ export const ensureProjectAndUser = async (vtex_account: string, user_email: str
   return response;
 }
 
-export const startCrawling = async (vtex_account: string, url: string, channel: CrawlingChannel) => {
+export interface WhatsAppChannelData {
+  auth_code: string;
+  waba_id: string;
+  phone_number_id: string;
+}
+
+export const startOnboardingSetup = async (
+  vtex_account: string,
+  url: string,
+  channel: SetupChannel,
+  channelData?: WhatsAppChannelData,
+) => {
   const response = await proxy<{ status: string }>(
     'POST',
-    `${getEnv('VITE_APP_COMMERCE_URL')}/api/onboard/${vtex_account}/start-crawling/`,
+    `${getEnv('VITE_APP_COMMERCE_URL')}/api/onboard/${vtex_account}/start-setup/`,
     {
-      data: { 
+      data: {
         crawl_url: `https://${url}`,
         channel,
+        ...(channelData && { channel_data: channelData }),
       },
     }
   );
@@ -79,7 +91,7 @@ export const updateWebchatDisplayRatio = async (
   return response;
 }
 
-export const activatePixelApp = async (channel: CrawlingChannel, appUuid: string, accountId: string) => {
+export const activatePixelApp = async (channel: SetupChannel, appUuid: string, accountId: string) => {
   const response = await proxy<{ uuid: string }>(
     'POST',
     `${getEnv('VITE_APP_COMMERCE_URL')}/api/onboard/${channel}/activate/`,

--- a/src/constants/onboarding.ts
+++ b/src/constants/onboarding.ts
@@ -1,16 +1,22 @@
 import type { OnboardChannel } from '../interfaces/Store';
 
-export type CrawlingChannel = 'wwc' | 'wpp-cloud';
+export const ONBOARD_CHANNEL = {
+  WEBCHAT: 'webchat',
+  WHATSAPP: 'whatsapp',
+} as const satisfies Record<string, OnboardChannel>;
 
-export const CRAWLING_CHANNEL: Record<OnboardChannel, CrawlingChannel> = {
-  webchat: 'wwc',
-  whatsapp: 'wpp-cloud',
+export type SetupChannel = 'wwc' | 'wpp-cloud';
+
+export const SETUP_CHANNEL: Record<OnboardChannel, SetupChannel> = {
+  [ONBOARD_CHANNEL.WEBCHAT]: 'wwc',
+  [ONBOARD_CHANNEL.WHATSAPP]: 'wpp-cloud',
 } as const;
 
 export const ONBOARDING_PAGES = {
   ONBOARD_CHANNEL_SELECTION: 'ONBOARD_CHANNEL_SELECTION',
   ONBOARD_WEBCHAT_SETUP: 'ONBOARD_WEBCHAT_SETUP',
   ONBOARD_WEBCHAT_TEST: 'ONBOARD_WEBCHAT_TEST',
+  ONBOARD_WHATSAPP_SETUP: 'ONBOARD_WHATSAPP_SETUP',
   ONBOARD_LEGACY: 'ONBOARD_LEGACY',
 } as const;
 

--- a/src/interfaces/Store.ts
+++ b/src/interfaces/Store.ts
@@ -1,4 +1,4 @@
-import { CrawlingChannel } from "../constants/onboarding";
+import { SetupChannel } from "../constants/onboarding";
 
 export interface AuthState {
   token: string;
@@ -139,7 +139,7 @@ export interface OnboardStatus {
   crawler_result?: string;
   config?: {
     channels: {
-      [key in CrawlingChannel]?: {
+      [key in SetupChannel]?: {
         app_uuid: string | null;
       }
     }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -70,6 +70,18 @@
       "placeholder": "Choose your store's URL",
       "help_text": "Confirm your original URL so we can build a precise knowledge base for your agents."
     },
+    "whatsapp_activation": {
+      "title": "How do you want to activate WhatsApp?",
+      "sandbox": {
+        "title": "Use a test number (Sandbox)",
+        "tag": "Fastest",
+        "description": "Use a temporary VTEX Agentic number to validate your flows right now. After testing, you can keep it as your permanent number or swap it for an official one at any time. <0>No Meta permissions or IT support required to start.</0>"
+      },
+      "official": {
+        "title": "Connect your official number",
+        "description": "Log in to Meta to authorize messaging through your official Business Manager account."
+      }
+    },
     "onboard_setup": {
       "title": "Your AI Team is getting ready",
       "test_button": "Test",

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -70,6 +70,18 @@
             "placeholder": "Elige la URL de tu tienda",
             "help_text": "Confirma tu URL original para que podamos construir una base de conocimiento precisa para tus agentes."
         },
+        "whatsapp_activation": {
+            "title": "¿Cómo quieres activar WhatsApp?",
+            "sandbox": {
+                "title": "Usar un número de prueba (Sandbox)",
+                "tag": "Más rápido",
+                "description": "Usa un número temporal VTEX Agentic para validar tus flujos ahora. Después de las pruebas, puedes mantenerlo como número permanente o cambiarlo por uno oficial en cualquier momento. <0>Sin permisos de Meta ni soporte de TI necesarios para comenzar.</0>"
+            },
+            "official": {
+                "title": "Conectar tu número oficial",
+                "description": "Inicia sesión en Meta para autorizar el envío de mensajes a través de tu cuenta oficial de Business Manager."
+            }
+        },
         "onboard_setup": {
             "title": "Tu equipo de IA se está preparando",
             "test_button": "Probar",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -64,6 +64,18 @@
             "placeholder": "Escolha a URL da sua loja",
             "help_text": "Confirme sua URL original para que possamos construir uma base de conhecimento precisa para seus agentes."
         },
+        "whatsapp_activation": {
+            "title": "Como você quer ativar o WhatsApp?",
+            "sandbox": {
+                "title": "Usar um número de teste (Sandbox)",
+                "tag": "Mais rápido",
+                "description": "Use um número temporário VTEX Agentic para validar seus fluxos agora. Depois dos testes, você pode mantê-lo como número permanente ou trocá-lo por um oficial a qualquer momento. <0>Sem permissões da Meta ou suporte de TI necessários para começar.</0>"
+            },
+            "official": {
+                "title": "Conectar seu número oficial",
+                "description": "Faça login na Meta para autorizar o envio de mensagens através da sua conta oficial do Business Manager."
+            }
+        },
         "onboard_setup": {
             "title": "Seu time de Agentes de IA está sendo preparado",
             "test_button": "Testar",

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -3,6 +3,7 @@ import { selectOnboardingStatus } from "../store/onboardSlice";
 import { ChannelSelection } from "./onboarding/channelSelection/ChannelSelection";
 import { WebchatOnboardSetup } from "./onboarding/webchat/WebchatOnboardSetup";
 import { WebchatTestAndActivate } from "./onboarding/webchat/WebchatTestAndActivate";
+import { WhatsAppOnboardSetup } from "./onboarding/whatsapp/WhatsAppOnboardSetup";
 import { LegacyOnboarding } from "./onboarding/legacyOnboarding/LegacyOnboarding";
 import { ONBOARDING_PAGES } from "../constants/onboarding";
 
@@ -10,6 +11,7 @@ const PAGE_COMPONENTS: Record<string, React.ComponentType> = {
   [ONBOARDING_PAGES.ONBOARD_CHANNEL_SELECTION]: ChannelSelection,
   [ONBOARDING_PAGES.ONBOARD_WEBCHAT_SETUP]: WebchatOnboardSetup,
   [ONBOARDING_PAGES.ONBOARD_WEBCHAT_TEST]: WebchatTestAndActivate,
+  [ONBOARDING_PAGES.ONBOARD_WHATSAPP_SETUP]: WhatsAppOnboardSetup,
   [ONBOARDING_PAGES.ONBOARD_LEGACY]: LegacyOnboarding,
 };
 

--- a/src/pages/onboarding/channelSelection/ChannelSelection.tsx
+++ b/src/pages/onboarding/channelSelection/ChannelSelection.tsx
@@ -5,10 +5,13 @@ import { Flex, Grid, Heading, Text } from "@vtex/shoreline";
 import { OnboardChannel } from "../../../interfaces/Store";
 import { setSelectedChannel, selectOnboardingStatus, setOnboardingStatus } from "../../../store/onboardSlice";
 import { selectAccount, selectUser } from "../../../store/userSlice";
-import { startCrawling, updateOnboarding } from "../../../services/onboarding.service";
+import { startOnboardingSetup, updateOnboarding } from "../../../services/onboarding.service";
+import { startFacebookLogin } from "../../../utils/facebook/login";
+import type { FacebookLoginResult } from "../../../utils/facebook/login";
 import { ChannelCard } from "./ChannelCard";
 import { SelectAccountHostModal } from "./SelectAccountHostModal";
-import { CRAWLING_CHANNEL, ONBOARDING_PAGES } from "../../../constants/onboarding";
+import { WhatsAppActivationModal } from "./WhatsAppActivationModal";
+import { ONBOARD_CHANNEL, SETUP_CHANNEL, ONBOARDING_PAGES } from "../../../constants/onboarding";
 import { TermsAndConditionsModal } from "./TermsAndConditionsModal";
 
 export function ChannelSelection() {
@@ -19,43 +22,36 @@ export function ChannelSelection() {
   const accountData = useSelector(selectAccount);
   const userData = useSelector(selectUser);
 
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isWebchatHostModalOpen, setIsWebchatHostModalOpen] = useState(false);
   const [isTermsModalOpen, setIsTermsModalOpen] = useState(false);
+  const [isWhatsAppActivationModalOpen, setIsWhatsAppActivationModalOpen] = useState(false);
+  const [isWhatsAppLoginLoading, setIsWhatsAppLoginLoading] = useState(false);
+  const [isWhatsAppHostModalOpen, setIsWhatsAppHostModalOpen] = useState(false);
+  const [whatsAppCredentials, setWhatsAppCredentials] = useState<FacebookLoginResult | null>(null);
 
   const hosts = accountData?.hosts ?? [];
 
   function handleCardClick(channel: OnboardChannel) {
     dispatch(setSelectedChannel(channel));
 
-    if (channel === "webchat") {
-      setIsModalOpen(true);
+    if (channel === ONBOARD_CHANNEL.WEBCHAT) {
+      setIsWebchatHostModalOpen(true);
       return;
     }
 
-    navigateToLegacyOnboarding();
+    if (channel === ONBOARD_CHANNEL.WHATSAPP) {
+      setIsWhatsAppActivationModalOpen(true);
+      return;
+    }
   }
 
-  async function navigateToLegacyOnboarding() {
-    const vtexAccount = userData?.account;
-    if (!vtexAccount) return;
-
-    updateOnboarding(vtexAccount, { current_page: ONBOARDING_PAGES.ONBOARD_LEGACY });
-
-    dispatch(
-      setOnboardingStatus({
-        ...onboardingStatus!,
-        current_page: ONBOARDING_PAGES.ONBOARD_LEGACY,
-      }),
-    );
-  }
-
-  async function handleConfirm(host: string) {
+  async function handleWebchatHostConfirm(host: string) {
     const vtexAccount = userData?.account;
     if (!vtexAccount) return;
 
     updateOnboarding(vtexAccount, { current_page: ONBOARDING_PAGES.ONBOARD_WEBCHAT_SETUP });
 
-    startCrawling(vtexAccount, host, CRAWLING_CHANNEL.webchat);
+    startOnboardingSetup(vtexAccount, host, SETUP_CHANNEL.webchat);
 
     dispatch(
       setOnboardingStatus({
@@ -64,7 +60,50 @@ export function ChannelSelection() {
       }),
     );
 
-    setIsModalOpen(false);
+    setIsWebchatHostModalOpen(false);
+  }
+
+  function handleWhatsAppContinue() {
+    setIsWhatsAppLoginLoading(true);
+
+    startFacebookLogin("", {
+      onSuccess: handleFacebookLoginSuccess,
+      onCancel: handleFacebookLoginCancel,
+    });
+  }
+
+  function handleFacebookLoginSuccess(result: FacebookLoginResult) {
+    setIsWhatsAppLoginLoading(false);
+    setIsWhatsAppActivationModalOpen(false);
+    setWhatsAppCredentials(result);
+    setIsWhatsAppHostModalOpen(true);
+  }
+
+  function handleFacebookLoginCancel() {
+    setIsWhatsAppLoginLoading(false);
+  }
+
+  async function handleWhatsAppHostConfirm(host: string) {
+    const vtexAccount = userData?.account;
+    if (!vtexAccount || !whatsAppCredentials) return;
+
+    await startOnboardingSetup(vtexAccount, host, SETUP_CHANNEL.whatsapp, {
+      auth_code: whatsAppCredentials.code,
+      waba_id: whatsAppCredentials.wabaId,
+      phone_number_id: whatsAppCredentials.phoneId,
+    });
+
+    updateOnboarding(vtexAccount, { current_page: ONBOARDING_PAGES.ONBOARD_WHATSAPP_SETUP });
+
+    dispatch(
+      setOnboardingStatus({
+        ...onboardingStatus!,
+        current_page: ONBOARDING_PAGES.ONBOARD_WHATSAPP_SETUP,
+      }),
+    );
+
+    setIsWhatsAppHostModalOpen(false);
+    setWhatsAppCredentials(null);
   }
 
   return (
@@ -99,7 +138,7 @@ export function ChannelSelection() {
           description={t("onboarding.channel_selection.webchat.description")}
           benefits={t("onboarding.channel_selection.webchat.benefits", { returnObjects: true }) as string[]}
           footer={t("onboarding.channel_selection.webchat.footer")}
-          onClick={() => handleCardClick("webchat")}
+          onClick={() => handleCardClick(ONBOARD_CHANNEL.WEBCHAT)}
           isRecommended
         />
 
@@ -108,7 +147,7 @@ export function ChannelSelection() {
           description={t("onboarding.channel_selection.whatsapp.description")}
           benefits={t("onboarding.channel_selection.whatsapp.benefits", { returnObjects: true }) as string[]}
           footer={t("onboarding.channel_selection.whatsapp.footer")}
-          onClick={() => handleCardClick("whatsapp")}
+          onClick={() => handleCardClick(ONBOARD_CHANNEL.WHATSAPP)}
         />
       </Grid>
 
@@ -133,9 +172,26 @@ export function ChannelSelection() {
       </Flex>
 
       <SelectAccountHostModal
-        open={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        onConfirm={handleConfirm}
+        open={isWebchatHostModalOpen}
+        onClose={() => setIsWebchatHostModalOpen(false)}
+        onConfirm={handleWebchatHostConfirm}
+        hosts={hosts}
+      />
+
+      <WhatsAppActivationModal
+        open={isWhatsAppActivationModalOpen}
+        isLoading={isWhatsAppLoginLoading}
+        onClose={() => setIsWhatsAppActivationModalOpen(false)}
+        onContinue={handleWhatsAppContinue}
+      />
+
+      <SelectAccountHostModal
+        open={isWhatsAppHostModalOpen}
+        onClose={() => {
+          setIsWhatsAppHostModalOpen(false);
+          setWhatsAppCredentials(null);
+        }}
+        onConfirm={handleWhatsAppHostConfirm}
         hosts={hosts}
       />
 

--- a/src/pages/onboarding/channelSelection/WhatsAppActivationModal.tsx
+++ b/src/pages/onboarding/channelSelection/WhatsAppActivationModal.tsx
@@ -1,0 +1,156 @@
+import { useState } from "react";
+import { useTranslation, Trans } from "react-i18next";
+import {
+  Button,
+  Flex,
+  Modal,
+  ModalContent,
+  ModalDismiss,
+  ModalFooter,
+  ModalHeader,
+  ModalHeading,
+  Tag,
+  Text,
+} from "@vtex/shoreline";
+
+export type WhatsAppActivationMethod = "sandbox" | "official";
+
+export interface WhatsAppActivationModalProps {
+  open: boolean;
+  isLoading: boolean;
+  onClose: () => void;
+  onContinue: (method: WhatsAppActivationMethod) => void;
+}
+
+interface OptionCardProps {
+  selected: boolean;
+  onSelect: () => void;
+  title: string;
+  description: React.ReactNode;
+  tag?: string;
+  disabled?: boolean;
+}
+
+function OptionCard({ selected, onSelect, title, description, tag, disabled }: OptionCardProps) {
+  return (
+    <Flex
+      onClick={disabled ? undefined : onSelect}
+      direction="column"
+      gap="$space-2"
+      style={{
+        border: selected
+          ? "1px solid var(--sl-color-blue-8)"
+          : "1px solid var(--sl-color-gray-4)",
+        borderRadius: "var(--sl-radius-2)",
+        padding: "var(--sl-space-5)",
+        backgroundColor: selected ? "var(--sl-color-blue-1)" : "var(--sl-color-white)",
+        cursor: disabled ? "default" : "pointer",
+        opacity: disabled ? 0.6 : 1,
+        width: "100%",
+      }}
+    >
+      <Flex justify="space-between" align="center">
+        <Flex gap="$space-2" align="center">
+          <RadioIndicator checked={selected} />
+          <Text variant="display3">{title}</Text>
+        </Flex>
+        {tag && <Tag color="blue" variant="primary">{tag}</Tag>}
+      </Flex>
+      <Text variant="caption2" color="$fg-base-soft">
+        {description}
+      </Text>
+    </Flex>
+  );
+}
+
+function RadioIndicator({ checked }: { checked: boolean }) {
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: 20,
+        height: 20,
+        borderRadius: "50%",
+        border: checked
+          ? "2px solid var(--sl-color-blue-8)"
+          : "2px solid var(--sl-color-gray-6)",
+        backgroundColor: "var(--sl-color-white)",
+        flexShrink: 0,
+      }}
+    >
+      {checked && (
+        <span
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: "50%",
+            backgroundColor: "var(--sl-color-blue-8)",
+          }}
+        />
+      )}
+    </span>
+  );
+}
+
+export function WhatsAppActivationModal({
+  open,
+  isLoading,
+  onClose,
+  onContinue,
+}: WhatsAppActivationModalProps) {
+  const { t } = useTranslation();
+  const [selected, setSelected] = useState<WhatsAppActivationMethod>("sandbox");
+
+  function handleClose() {
+    if (isLoading) return;
+    setSelected("sandbox");
+    onClose();
+  }
+
+  function handleContinue() {
+    onContinue(selected);
+  }
+
+  return (
+    <Modal open={open} onClose={handleClose} size="large">
+      <ModalHeader>
+        <ModalHeading>{t("onboarding.whatsapp_activation.title")}</ModalHeading>
+        {!isLoading && <ModalDismiss />}
+      </ModalHeader>
+
+      <ModalContent>
+        <Flex direction="column" gap="$space-3">
+          <OptionCard
+            selected={selected === "sandbox"}
+            onSelect={() => !isLoading && setSelected("sandbox")}
+            title={t("onboarding.whatsapp_activation.sandbox.title")}
+            tag={t("onboarding.whatsapp_activation.sandbox.tag")}
+            description={
+              <Trans
+                i18nKey="onboarding.whatsapp_activation.sandbox.description"
+                components={[<Text as="span" variant="caption1" />]}
+              />
+            }
+            disabled={isLoading}
+          />
+
+          <OptionCard
+            selected={selected === "official"}
+            onSelect={() => !isLoading && setSelected("official")}
+            title={t("onboarding.whatsapp_activation.official.title")}
+            description={t("onboarding.whatsapp_activation.official.description")}
+            disabled={isLoading}
+          />
+        </Flex>
+      </ModalContent>
+
+      <ModalFooter>
+        <Button variant="primary" onClick={handleContinue} loading={isLoading} disabled={isLoading}>
+          {t("common.continue")}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/src/pages/onboarding/webchat/WebchatTestAndActivate.tsx
+++ b/src/pages/onboarding/webchat/WebchatTestAndActivate.tsx
@@ -19,7 +19,7 @@ import {
 import { WebchatOnboardingLayout } from './WebchatOnboardingLayout';
 import { UseCaseId } from './webchatUseCases';
 import { Instructions } from '../../../components/manager/Instructions';
-import { CRAWLING_CHANNEL } from '../../../constants/onboarding';
+import { SETUP_CHANNEL } from '../../../constants/onboarding';
 import { ActivationSection } from '../../../components/shared/ActivationSection';
 import { DISPLAY_RATIO } from '../../../components/shared/activationConstants';
 import type { ActivationMode } from '../../../components/shared/activationConstants';
@@ -115,7 +115,7 @@ export function WebchatTestAndActivate() {
 
     setIsActivating(true);
     try {
-      const activation = await activateInStore(CRAWLING_CHANNEL.webchat, webchatAppUuid, vtexAccountId);
+      const activation = await activateInStore(SETUP_CHANNEL.webchat, webchatAppUuid, vtexAccountId);
       if (activation.success) {
         await updateOnboarding(vtexAccount, { completed: true });
         dispatch(setOnboardingStatus({

--- a/src/services/onboarding.service.ts
+++ b/src/services/onboarding.service.ts
@@ -2,12 +2,13 @@ import {
   ActivateInStoreResponse,
   EnsureProjectAndUserResponse,
   OnboardStatusResponse,
-  StartCrawlingResponse,
+  StartOnboardingSetupResponse,
   UpdateDisplayRatioResponse,
   UpdateOnboardingResponse,
   VTEXOnboardAdapter,
 } from "../api/onboarding/adapters";
-import type { CrawlingChannel } from "../constants/onboarding";
+import type { SetupChannel } from "../constants/onboarding";
+import type { WhatsAppChannelData } from "../api/onboarding/requests";
 
 const onboardingAdapter = new VTEXOnboardAdapter();
 
@@ -19,8 +20,13 @@ export async function ensureProjectAndUser(vtex_account: string, user_email: str
   return onboardingAdapter.ensureProjectAndUser(vtex_account, user_email);
 }
 
-export async function startCrawling(vtex_account: string, url: string, channel: CrawlingChannel): Promise<StartCrawlingResponse> {
-  return onboardingAdapter.startCrawling(vtex_account, url, channel);
+export async function startOnboardingSetup(
+  vtex_account: string,
+  url: string,
+  channel: SetupChannel,
+  channelData?: WhatsAppChannelData,
+): Promise<StartOnboardingSetupResponse> {
+  return onboardingAdapter.startOnboardingSetup(vtex_account, url, channel, channelData);
 }
 
 export async function updateOnboarding(
@@ -51,7 +57,7 @@ export async function updateDisplayRatio(
 }
 
 export async function activateInStore(
-  channel: CrawlingChannel,
+  channel: SetupChannel,
   appUuid: string,
   accountId: string,
 ): Promise<ActivateInStoreResponse> {

--- a/src/utils/facebook/login.ts
+++ b/src/utils/facebook/login.ts
@@ -4,6 +4,17 @@ import getEnv from "../env";
 import { setWppLoading } from "../../store/projectSlice";
 import store from "../../store/provider.store";
 
+export interface FacebookLoginResult {
+    code: string;
+    wabaId: string;
+    phoneId: string;
+}
+
+export interface FacebookLoginOptions {
+    onSuccess?: (result: FacebookLoginResult) => void;
+    onCancel?: () => void;
+}
+
 const LOGIN_TIMEOUT_MS = 10 * 60 * 1000;
 
 function initFacebookSDK(appId: string, loginCallback: () => Promise<void>) {
@@ -75,7 +86,7 @@ function resetLoginState() {
     store.dispatch(setWppLoading(false));
 }
 
-export function startFacebookLogin(project_uuid: string) {
+export function startFacebookLogin(project_uuid: string, options?: FacebookLoginOptions) {
     const fbAppId = getEnv("VITE_APP_FACEBOOK_APP_ID");
     const configId = getEnv("VITE_APP_WHATSAPP_FACEBOOK_APP_ID");
 
@@ -151,6 +162,7 @@ export function startFacebookLogin(project_uuid: string) {
         loginTimeoutId = setTimeout(() => {
             console.warn("Facebook login timed out, cleaning up.");
             resetLoginState();
+            options?.onCancel?.();
         }, LOGIN_TIMEOUT_MS);
 
         FB.login(
@@ -162,20 +174,27 @@ export function startFacebookLogin(project_uuid: string) {
                     console.error("Login canceled or not fully authorized.");
                     loginInProgress = false;
                     store.dispatch(setWppLoading(false));
+                    options?.onCancel?.();
                     return;
                 }
 
                 const code = response.authResponse.code;
                 console.log("Login Successful.");
 
-                createChannel(code, project_uuid, wabaId, phoneId)
-                    .catch((error) => {
-                        console.error("Failed to create channel:", error);
-                    })
-                    .finally(() => {
-                        loginInProgress = false;
-                        store.dispatch(setWppLoading(false));
-                    });
+                if (options?.onSuccess) {
+                    options.onSuccess({ code, wabaId, phoneId });
+                    loginInProgress = false;
+                    store.dispatch(setWppLoading(false));
+                } else {
+                    createChannel(code, project_uuid, wabaId, phoneId)
+                        .catch((error) => {
+                            console.error("Failed to create channel:", error);
+                        })
+                        .finally(() => {
+                            loginInProgress = false;
+                            store.dispatch(setWppLoading(false));
+                        });
+                }
             },
             loginOptions
         );


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context

The WhatsApp onboarding flow previously redirected users to a legacy page. This PR replaces that with a new guided multi-step flow: users choose an activation method, authenticate via Facebook Embedded Signup, select a store host, and are routed to a dedicated WhatsApp setup page. This aligns the WhatsApp channel onboarding with the same quality and structure as the webchat flow.

### Summary of Changes

**New WhatsApp activation modal** (`WhatsAppActivationModal.tsx`)
- Two radio-card options ("Use a test number / Sandbox" and "Connect your official number") matching the Figma design.
- Continue button with loading/disabled state while the Facebook login popup is open.
- Options are visual-only for now; the selected method is passed through for future extensibility.

**Facebook login util extended** (`login.ts`)
- `startFacebookLogin` now accepts optional `onSuccess` and `onCancel` callbacks.
- When `onSuccess` is provided, credentials (`code`, `wabaId`, `phoneId`) are returned without creating a channel.
- When omitted, existing `createChannel` behavior is preserved (backward compatible).
- `onCancel` fires on user cancellation or timeout, so callers can reset UI state.

**ChannelSelection orchestration rewrite**
- WhatsApp card click now opens the activation modal instead of navigating to legacy onboarding.
- Multi-step state machine: activation modal -> Facebook login -> host selection modal -> v2 API call -> page navigation.
- Webchat flow refactored for naming clarity (`isModalOpen` -> `isWebchatHostModalOpen`, `handleConfirm` -> `handleWebchatHostConfirm`).

**Naming refactor**
- `CrawlingChannel` -> `SetupChannel`, `CRAWLING_CHANNEL` -> `SETUP_CHANNEL`, `startCrawling` -> `startOnboardingSetup` across constants, requests, adapters, and services.
- Old `/start-crawling/` endpoint updated to `/start-setup/`.

**i18n**
- `onboarding.whatsapp_activation` keys added to `en.json`, `pt-BR.json`, and `es-ES.json`.

