### PR TITLE
feat: add deprecation modal for CX Dashboard migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.5.0] - 2026-04-15
+
+### Changed
+- feat: add deprecation modal for CX Dashboard migration
+
+## [2.4.2] - 2026-03-27
+
+### Changed
+- feat: Prevent Pixel Script From Loading Multiple Times
+
 ## [2.4.1] - 2026-03-19
 
 ### Fixed

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { AgentIndex } from './pages/agent/Index';
 import { Onboarding } from './pages/Onboarding';
 import { Adapters } from './pages/Adapters';
 import { BillingPlans } from './pages/billing/BillingPlans';
+import { DeprecationModal } from './components/DeprecationModal';
 
 function App() {
   const dispatch = useDispatch();
@@ -30,6 +31,7 @@ function App() {
 
   return (
     <>
+      <DeprecationModal />
       {isInitialLoading ? (
         <Grid
           rows="1fr"

--- a/src/components/DeprecationModal.tsx
+++ b/src/components/DeprecationModal.tsx
@@ -1,0 +1,53 @@
+import {
+  Button,
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalHeading,
+  Text,
+} from '@vtex/shoreline';
+import { Trans, useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+import { selectUser } from '../store/userSlice';
+
+export function DeprecationModal() {
+  const { t } = useTranslation();
+  const user = useSelector(selectUser);
+  const account = user?.account;
+
+  function handleGoToDashboard() {
+    window.open(`https://${account}.myvtex.com/admin/agentic-cx`, '_blank');
+  }
+
+  if (!account) {
+    return null;
+  }
+
+  return (
+    <Modal open onClose={() => {}}>
+      <ModalHeader>
+        <ModalHeading>{t('deprecation_modal.title')}</ModalHeading>
+      </ModalHeader>
+
+      <ModalContent>
+        <Text variant="body">
+          <Trans
+            i18nKey="deprecation_modal.description"
+            components={[<strong />]}
+          />
+        </Text>
+
+        <Text variant="body">
+          {t('deprecation_modal.discontinuation_notice')}
+        </Text>
+      </ModalContent>
+
+      <ModalFooter>
+        <Button variant="primary" size="large" onClick={handleGoToDashboard}>
+          {t('deprecation_modal.go_to_dashboard')}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -28,6 +28,12 @@
     "clear": "Clear",
     "apply": "Apply"
   },
+  "deprecation_modal": {
+    "description": "CX Dashboard is now available at <0>Storefront > CX > Dashboard</0>, fully functional with all your data and settings preserved.",
+    "discontinuation_notice": "This app will be discontinued. We recommend accessing it from the new location from now on.",
+    "go_to_dashboard": "Go to Dashboard",
+    "title": "CX Dashboard has moved"
+  },
   "onboarding": {
     "select_agent": {
       "title": "Assign the first agent into your team"

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -28,6 +28,12 @@
         "clear": "Limpiar",
         "apply": "Aplicar"
     },
+    "deprecation_modal": {
+        "description": "CX Dashboard ahora está disponible en <0>Storefront > CX > Dashboard</0>, completamente funcional con todos los datos y configuraciones preservados.",
+        "discontinuation_notice": "Esta aplicación será descontinuada. Recomendamos acceder desde la nueva ubicación.",
+        "go_to_dashboard": "Ir al Dashboard",
+        "title": "CX Dashboard cambió de ubicación"
+    },
     "onboarding": {
         "select_agent": {
             "title": "Asignar el primer agente a tu equipo"

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -28,6 +28,12 @@
         "clear": "Limpar",
         "apply": "Aplicar"
     },
+    "deprecation_modal": {
+        "description": "O CX Dashboard agora está disponível em <0>Storefront > CX > Dashboard</0>, totalmente funcional com todos os dados e configurações preservados.",
+        "discontinuation_notice": "Este aplicativo será descontinuado. Recomendamos acessá-lo a partir do novo local.",
+        "go_to_dashboard": "Ir para o Dashboard",
+        "title": "O CX Dashboard mudou de lugar"
+    },
     "onboarding": {
         "channel_selection": {
             "title": "A plataforma de Experiência Conversacional Inteligente da VTEX para marcas e varejistas.",


### PR DESCRIPTION
## Summary

- Adds a non-dismissable modal displayed on every page load informing users that CX Dashboard has moved to **Storefront > CX > Dashboard**
- The "Go to Dashboard" button opens the new location (`https://{account}.myvtex.com/admin/agentic-cx`) in a new tab
- Modal only renders once the VTEX account data is available from Redux, preventing broken URLs on initial load
- Translations added for EN, PT-BR, and ES following VTEX Content Guide standards

## Test plan

- [ ] Verify the modal appears on every page load (no dismiss, no "show once" behavior)
- [ ] Verify the modal has no close/dismiss button (X or backdrop click)
- [ ] Verify the "Go to Dashboard" button opens the correct URL in a new tab: `https://{account}.myvtex.com/admin/agentic-cx`
- [ ] Verify the modal does not render before user account data is loaded (no broken URL)
- [ ] Verify translations render correctly for EN, PT-BR, and ES
- [ ] Verify "Storefront > CX > Dashboard" appears in bold in the description text


Made with [Cursor](https://cursor.com)